### PR TITLE
241016 CD to AWS 4.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
           aws-region: ap-northeast-2
 
       - name: Start Session Manager session
-        run: aws ssm start-session --target "${{ secrets.EC2_INSTANCE_ID }}"
+        run: aws ssm start-session --target i-0f2195f7c4d0965cc
 
       - name: Deploy to Server
         env:


### PR DESCRIPTION
전의 에러가 해결되지 않아

""를 제거하고 시크릿이 아니라 값을 직접 넣음